### PR TITLE
fix filter contribution to approximate_size_of

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.3.1"
+version = "0.3.2"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard/"
 description = "Clubcard is an exact membership query filter for static sets"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -401,6 +401,9 @@ impl<const W: usize, T: Filterable<W>, ApproxOrExact> From<Vec<Ribbon<W, T, Appr
                     tail = blocks[j].solve(&tail);
                 }
             }
+            while let Some(0) = tail.last() {
+                tail.pop();
+            }
             solution.push(tail);
         }
 

--- a/src/clubcard.rs
+++ b/src/clubcard.rs
@@ -188,7 +188,9 @@ where
         self.universe.approximate_size_of()
             + self.partition.approximate_size_of()
             + self.index.approximate_size_of()
+            + size_of::<Vec<Vec<u8>>>()
             + 8 * self.approx_filter.iter().map(|x| x.len()).sum::<usize>()
+            + size_of::<Vec<u8>>()
             + 8 * self.exact_filter.len()
     }
 }

--- a/src/clubcard.rs
+++ b/src/clubcard.rs
@@ -184,7 +184,7 @@ where
         self.universe.approximate_size_of()
             + self.partition.approximate_size_of()
             + self.index.approximate_size_of()
-            + self.approx_filter.iter().map(|x| x.len()).sum::<usize>()
-            + self.exact_filter.len()
+            + 8 * self.approx_filter.iter().map(|x| x.len()).sum::<usize>()
+            + 8 * self.exact_filter.len()
     }
 }

--- a/src/clubcard.rs
+++ b/src/clubcard.rs
@@ -154,6 +154,10 @@ impl<const W: usize, UniverseMetadata, PartitionMetadata>
     pub fn partition(&self) -> &PartitionMetadata {
         &self.partition
     }
+
+    pub fn index(&self) -> &ClubcardIndex {
+        &self.index
+    }
 }
 
 /// Helper trait for (approximate) heap memory usage analysis in Firefox

--- a/src/clubcard.rs
+++ b/src/clubcard.rs
@@ -75,12 +75,12 @@ impl<const W: usize, UniverseMetadata, PartitionMetadata> fmt::Display
             .sum::<usize>();
         writeln!(
             f,
-            "Clubcard of size {} ({} + {})",
+            "Clubcard of size {} ({} + {}) with {} exceptions",
             approx_size + exact_size,
             approx_size,
-            exact_size
-        )?;
-        writeln!(f, "- exceptions: {}", exceptions)
+            exact_size,
+            exceptions
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 pub mod builder;
 
 mod clubcard;
-pub use clubcard::{ApproximateSizeOf, Clubcard, ClubcardIndexEntry, Membership};
+pub use clubcard::{ApproximateSizeOf, Clubcard, ClubcardIndex, ClubcardIndexEntry, Membership};
 
 mod equation;
 pub use equation::Equation;


### PR DESCRIPTION
The filter vectors are of type `Vec<u64>`, so we need to multiply by 8 to get the byte size for `approximate_size_of`.

This PR also exposes some functionality for https://github.com/mozilla/clubcard-crlite/pull/4