### PR TITLE
Expose Clubcard fields publicly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clubcard"
 authors = ["John M. Schanck <jschanck@mozilla.com>"]
-version = "0.3.2"
+version = "0.3.3"
 license = "MPL-2.0"
 repository = "https://github.com/mozilla/clubcard/"
 description = "Clubcard is an exact membership query filter for static sets"

--- a/src/clubcard.rs
+++ b/src/clubcard.rs
@@ -51,15 +51,15 @@ pub type ClubcardIndex = BTreeMap</* block id */ Vec<u8>, ClubcardIndexEntry>;
 #[derive(Serialize, Deserialize)]
 pub struct Clubcard<const W: usize, UniverseMetadata, PartitionMetadata> {
     /// Metadata for determining whether a Queryable is in the encoded universe.
-    pub(crate) universe: UniverseMetadata,
+    pub universe: UniverseMetadata,
     /// Metadata for determining the block to which a Queryable belongs.
-    pub(crate) partition: PartitionMetadata,
+    pub partition: PartitionMetadata,
     /// Lookup table for per-block metadata.
-    pub(crate) index: ClubcardIndex,
+    pub index: ClubcardIndex,
     /// The matrix X
-    pub(crate) approx_filter: Vec<Vec<u64>>,
+    pub approx_filter: Vec<Vec<u64>>,
     /// The matrix Y
-    pub(crate) exact_filter: Vec<u64>,
+    pub exact_filter: Vec<u64>,
 }
 
 impl<const W: usize, UniverseMetadata, PartitionMetadata> fmt::Display


### PR DESCRIPTION
In order to support custom serialization/deserialization in downstream crates (clubcard_crlite), we need a way to access `Clubcard::approx_filter` and `Clubcard::exact_filter`. While we could access both a 5-argument constructor and two additional getters, I was thinking maybe it would be okay to just make the fields public?